### PR TITLE
Update in app browser without unhiding

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -256,8 +256,8 @@ public class InAppBrowser extends CordovaPlugin {
 
             canOpen = false;
             final String url = args.isNull(0) ? null : args.getString(0);
-            final boolean hide = args.isNull(1) ? false : args.getBoolean(1);
-            updateDialog(url, hide);
+            final boolean show = args.isNull(1) ? false : args.getBoolean(1);
+            updateDialog(url, show);
             return true;
         }
 
@@ -422,7 +422,7 @@ public class InAppBrowser extends CordovaPlugin {
         });
     }
 
-    private void updateDialog(final String url, final boolean hide) {
+    private void updateDialog(final String url, final boolean show) {
         if (url == null || url.equals("") || url.equals(NULL)) {
             addBridgeInterface();
             showDialogue();
@@ -449,7 +449,7 @@ public class InAppBrowser extends CordovaPlugin {
                 } else {
                     //unhidden event & reset of hidden flag done in onPageFinished which results from this navigate ...
 
-                    if (!hide) {
+                    if (show) {
                         reOpenOnNextPageFinished = true;
                     }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -249,6 +249,18 @@ public class InAppBrowser extends CordovaPlugin {
             return true;
         }
 
+        if (action.equals("update")) {
+            if (!canOpen) {
+                return true;
+            }
+
+            canOpen = false;
+            final String url = args.isNull(0) ? null : args.getString(0);
+            final boolean hide = args.isNull(1) ? false : args.getBoolean(1);
+            updateDialog(url, hide);
+            return true;
+        }
+
         return false;
     }
 
@@ -410,6 +422,42 @@ public class InAppBrowser extends CordovaPlugin {
         });
     }
 
+    private void updateDialog(final String url, final boolean hide) {
+        if (url == null || url.equals("") || url.equals(NULL)) {
+            addBridgeInterface();
+            showDialogue();
+            return;
+        }
+
+        if (!UrlSecurityValidation.shouldAllowRequest(webView, url)) {
+            return;
+        }
+
+        addBridgeInterface();
+
+        this.cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+
+                if (null == inAppWebView || null == inAppWebView.getUrl()) {
+                    return;
+                }
+
+                if (inAppWebView.getUrl().equals(url)) {
+                    //unhidden event & reset of hidden flag done in this method ...
+                    showDialogue();
+                } else {
+                    //unhidden event & reset of hidden flag done in onPageFinished which results from this navigate ...
+
+                    if (!hide) {
+                        reOpenOnNextPageFinished = true;
+                    }
+
+                    navigate(url);
+                }
+            }
+        });
+    }
 
 
     /**

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -255,9 +255,12 @@ public class InAppBrowser extends CordovaPlugin {
             }
 
             canOpen = false;
+
             final String url = args.isNull(0) ? null : args.getString(0);
-            final boolean show = args.isNull(1) ? false : args.getBoolean(1);
+            final boolean show = args.isNull(1) ? true : args.getBoolean(1);
+
             updateDialog(url, show);
+
             return true;
         }
 
@@ -425,7 +428,11 @@ public class InAppBrowser extends CordovaPlugin {
     private void updateDialog(final String url, final boolean show) {
         if (url == null || url.equals("") || url.equals(NULL)) {
             addBridgeInterface();
-            showDialogue();
+
+            if (show) {
+                showDialogue();
+            }
+
             return;
         }
 
@@ -438,17 +445,15 @@ public class InAppBrowser extends CordovaPlugin {
         this.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-
                 if (null == inAppWebView || null == inAppWebView.getUrl()) {
                     return;
                 }
 
                 if (inAppWebView.getUrl().equals(url)) {
-                    //unhidden event & reset of hidden flag done in this method ...
-                    showDialogue();
+                    if (show) {
+                        showDialogue();
+                    }
                 } else {
-                    //unhidden event & reset of hidden flag done in onPageFinished which results from this navigate ...
-
                     if (show) {
                         reOpenOnNextPageFinished = true;
                     }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -426,7 +426,7 @@ public class InAppBrowser extends CordovaPlugin {
     }
 
     private void updateDialog(final String url, final boolean show) {
-        if (url == null || url.equals("") || url.equals(NULL)) {
+        if (null == url || url.trim().isEmpty()) {
             addBridgeInterface();
 
             if (show) {

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -41,6 +41,7 @@
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)unHide:(CDVInvokedUrlCommand*)command;
+- (void)update:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -562,7 +562,7 @@ BOOL canOpen = YES;
 
 - (void)updateView:(NSString*)url targets:(NSString*)target withOptions:(NSString*)options show:(BOOL)show {
 	if (!canOpen) {
-		return;
+	    return;
 	}
 
 	canOpen = NO;
@@ -676,6 +676,7 @@ BOOL canOpen = YES;
     BOOL show = [[command argumentAtIndex:3] boolValue];
 
     self.callbackId = command.callbackId;
+
     [self updateView:url targets:target withOptions:options show:show];
 }
 

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -560,6 +560,20 @@ BOOL canOpen = YES;
     [self openUrl:url targets:target withOptions:options];
 }
 
+- (void)updateView:(NSString*)url targets:(NSString*)target withOptions:(NSString*)options hide:(BOOL)hide {
+	if (!canOpen) {
+		return;
+	}
+
+	canOpen = NO;
+
+	if (!hide) {
+	    unhiding = YES;
+	}
+
+    [self openUrl:url targets:target withOptions:options];
+}
+
 
 #pragma mark public-methods
 
@@ -653,6 +667,16 @@ BOOL canOpen = YES;
 
     self.callbackId = command.callbackId;
     [self unHideView:url targets:target withOptions:options];
+}
+
+- (void)update:(CDVInvokedUrlCommand*)command {
+    NSString* url = [command argumentAtIndex:0];
+    NSString* target = [command argumentAtIndex:1 withDefault:kInAppBrowserTargetSelf];
+    NSString* options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
+    BOOL hide = [[command argumentAtIndex:3] boolValue];
+
+    self.callbackId = command.callbackId;
+    [self updateView:url targets:target withOptions:options hide:hide];
 }
 
 @end

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -560,14 +560,14 @@ BOOL canOpen = YES;
     [self openUrl:url targets:target withOptions:options];
 }
 
-- (void)updateView:(NSString*)url targets:(NSString*)target withOptions:(NSString*)options hide:(BOOL)hide {
+- (void)updateView:(NSString*)url targets:(NSString*)target withOptions:(NSString*)options show:(BOOL)show {
 	if (!canOpen) {
 		return;
 	}
 
 	canOpen = NO;
 
-	if (!hide) {
+	if (show) {
 	    unhiding = YES;
 	}
 
@@ -673,10 +673,10 @@ BOOL canOpen = YES;
     NSString* url = [command argumentAtIndex:0];
     NSString* target = [command argumentAtIndex:1 withDefault:kInAppBrowserTargetSelf];
     NSString* options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
-    BOOL hide = [[command argumentAtIndex:3] boolValue];
+    BOOL show = [[command argumentAtIndex:3] boolValue];
 
     self.callbackId = command.callbackId;
-    [self updateView:url targets:target withOptions:options hide:hide];
+    [self updateView:url targets:target withOptions:options show:show];
 }
 
 @end

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -79,10 +79,10 @@
             hidden = false;
         }
 
-        me.update = function (strUrl, hide) {
-            exec(null,null,"InAppBrowser", "update", [strUrl, hide]);
+        me.update = function (strUrl, show) {
+            exec(null,null,"InAppBrowser", "update", [strUrl, show]);
 
-            if (!hide) {
+            if (show) {
                 hidden = false;
             }
         };

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -79,6 +79,14 @@
             hidden = false;
         }
 
+        me.update = function (strUrl, hide) {
+            exec(null,null,"InAppBrowser", "update", [strUrl, hide]);
+
+            if (!hide) {
+                hidden = false;
+            }
+        };
+
         me.bridge = function (objectName, bridgeFunction) {
             exec(null, null, "InAppBrowser", "bridge", [objectName, bridgeFunction]);
         }

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -136,6 +136,18 @@
             hidden = false;
         }
 
+        me.update = function (strUrl, hide) {
+            if (strUrl) {
+                lastUrl = urlutil.makeAbsolute(strUrl) || lastUrl || 'about:blank';
+            }
+
+            exec(eventCallback, eventCallback, "InAppBrowser", "update", [lastUrl, lastWindowName, lastWindowFeatures, hide]);
+
+            if (!hide) {
+                hidden = false;
+            }
+        };
+
         me.addEventListener = function (eventname,f) {
             if (eventname in me.channels) {
                 me.channels[eventname].subscribe(f);

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -136,14 +136,14 @@
             hidden = false;
         }
 
-        me.update = function (strUrl, hide) {
+        me.update = function (strUrl, show) {
             if (strUrl) {
                 lastUrl = urlutil.makeAbsolute(strUrl) || lastUrl || 'about:blank';
             }
 
-            exec(eventCallback, eventCallback, "InAppBrowser", "update", [lastUrl, lastWindowName, lastWindowFeatures, hide]);
+            exec(eventCallback, eventCallback, "InAppBrowser", "update", [lastUrl, lastWindowName, lastWindowFeatures, show]);
 
-            if (!hide) {
+            if (show) {
                 hidden = false;
             }
         };


### PR DESCRIPTION
There's currently an `unHide` method that can be used to update the in app browser.

Uk hybrid app needs the option of updating the in app browser whilst hidden, so this PR adds an `update` method with optional show flag.

This could replace the `unHide` method if other verticals also update to use this at some point. In the meantime to avoid any disruption, this will run alongside it.