### PR TITLE
Add missing browser event to update dialog

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -452,6 +452,9 @@ public class InAppBrowser extends CordovaPlugin {
                 if (inAppWebView.getUrl().equals(url)) {
                     if (show) {
                         showDialogue();
+                    } else {
+                        browserEventSender.loadStop(url);
+                        canOpen = true;
                     }
                 } else {
                     if (show) {


### PR DESCRIPTION
Resolves issue on Android, in which no browser event is received for a hidden update to the in-app browser if the current url matches the requested url.