### PR TITLE
Android 5.0+ third party cookies fix v2

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -839,6 +839,11 @@ public class InAppBrowser extends CordovaPlugin {
                     CookieManager.getInstance().removeSessionCookie();
                 }
 
+                // Enable Thirdparty Cookies on >=Android 5.0 device
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                    CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView,true);
+                }
+
                 addBridgeInterface();
 
                 inAppWebView.loadUrl(url);


### PR DESCRIPTION
Android V5.0 and above has third party cookies allowed set to false by default, where as below 5.0 defaulted to true.  This issue was discovered when creating a new account and trying to make your first deposit.  The in app browser would not send cookies when submitting your details and the in app browser would default to loading the home page, resulting in an infinite loop (if you kept trying) of the app loading inside an iframe, and inside the iframe that that app had etc.  This fixes that issue.