### PR TITLE
Android app crashes on some devices after hardware back exit

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -517,7 +517,11 @@ public class InAppBrowser extends CordovaPlugin {
                     // NB: wait for about:blank before dismissing
                     public void onPageFinished(WebView view, String url) {
                         if (dialog != null) {
-                            dialog.dismiss();
+                            try {
+                                dialog.dismiss();
+                            } catch (IllegalArgumentException e) {
+                            }
+
                             dialog = null;
                             childView.destroy();
                         }


### PR DESCRIPTION
UK Bingo Hybrid app is crashing on some Android devices (eg. Samsung Galaxy S6 Edge) after using the hardware back button to exit the app. This adds a try / catch block around the dialog dismiss call so that the exception is handled if unable to dismiss dialog on destroy.
