### PR TITLE
Bcw 3928/webview size incorrect on orientation change while loading

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -37,6 +37,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.WindowManager.LayoutParams;
+import android.view.WindowManager.BadTokenException;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.JavascriptInterface;
@@ -677,6 +678,11 @@ public class InAppBrowser extends CordovaPlugin {
             @SuppressLint("NewApi")
             public void run() {
 
+                // BCW-3720 - android.view.WindowManager$BadTokenException thrown
+                if (cordova.getActivity().isFinishing()) {
+                    return;
+                }
+
                 // CB-6702 InAppBrowser hangs when opening more than one instance
                 if (dialog != null) {
                     dialog.dismiss();
@@ -882,7 +888,11 @@ public class InAppBrowser extends CordovaPlugin {
                 lp.height = WindowManager.LayoutParams.MATCH_PARENT;
 
                 dialog.setContentView(main);
-                dialog.show();
+                // BCW-3720 - android.view.WindowManager$BadTokenException thrown
+                try {
+                    dialog.show();
+                } catch (BadTokenException e) {
+                }
                 dialog.getWindow().setAttributes(lp);
                 // the goal of openhidden is to load the url and not display it
                 // Show() needs to be called to cause the URL to be loaded

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -1029,6 +1029,8 @@ BOOL canOpen = YES;
     [self rePositionViews];
 
     [super viewWillAppear:animated];
+
+    [self.webView setFrame:[[UIScreen mainScreen] bounds]];
 }
 
 //

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -1026,11 +1026,10 @@ BOOL canOpen = YES;
     if (IsAtLeastiOSVersion(@"7.0")) {
         [[UIApplication sharedApplication] setStatusBarStyle:[self preferredStatusBarStyle]];
     }
+    [self.webView setFrame:[[UIScreen mainScreen] bounds]];
     [self rePositionViews];
 
     [super viewWillAppear:animated];
-
-    [self.webView setFrame:[[UIScreen mainScreen] bounds]];
 }
 
 //


### PR DESCRIPTION
### Platforms affected
Android
iOS

### What does this PR do?
(Android) Added safeguards against android.view.WindowManager$BadTokenException
- Added a check to avoid opening the dialog if the activity is finishing
- Wrapped the dialog.show() call in an try/catch to avoid crash if the other check doesn't work

(iOS) Fixed error with the webview displaying incorrectly if changing orientation while the page was still loading
- Set the webview to match the screen bounds on viewWillAppear



