### PR TITLE
Ic 5664/add support for custom url schemes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ cordova plugin add ../cordova-plugin-inappbrowser/tests
 cordova plugin add ../cordova-plugin-test-framework
 ```
 * edit ```config.xml``` and replace ```<content src="index.html" />``` with ```<content src="cdvtests/index.html" />```
+* edit ```config.xml``` and add ```<preference name="AllowedSchemes" value="custom" />```
 * run application
 ```
 cordova run

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The object returned from a call to `cordova.InAppBrowser.open` when the target i
   - __loadstop__: event fires when the `InAppBrowser` finishes loading a URL.
   - __loaderror__: event fires when the `InAppBrowser` encounters an error when loading a URL.
   - __exit__: event fires when the `InAppBrowser` window is closed.
+  - __customscheme__: event fires when a link is followed that matches `AllowedSchemes` (Android, iOS).
 
 - __callback__: the function that executes when the event fires. The function is passed an `InAppBrowserEvent` object as a parameter.
 
@@ -330,6 +331,10 @@ function executeScriptCallBack(params) {
 - Windows Phone 7 and 8
 - Browser
 
+### iOS Quirks
+
+`loadstop` is being fired after a `customscheme` event. The event URL is that of the currently loaded page, not the URL with the custom scheme.
+
 ### Browser Quirks
 
 `loadstart` and `loaderror` events are not being fired.
@@ -353,6 +358,7 @@ function executeScriptCallBack(params) {
   - __loadstop__: event fires when the `InAppBrowser` finishes loading a URL.
   - __loaderror__: event fires when the `InAppBrowser` encounters an error loading a URL.
   - __exit__: event fires when the `InAppBrowser` window is closed.
+  - __customscheme__: event fires when a link is followed that matches `AllowedSchemes` (Android, iOS).
 
 - __callback__: the function to execute when the event fires.
 The function is passed an `InAppBrowserEvent` object.
@@ -763,6 +769,34 @@ function executeScriptCallBack(params) {
 }
 
 ```
+
+### <a id="events_from_browser"></a>Events from the browser
+
+Sometimes you may want to respond to an event happening on the page loaded in the browser,
+for example a button to open the barcode scanner, or closing the browser when a login flow
+was finished. This can done by navigating to a URL with a custom scheme listed in the
+`AllowedSchemes` preference in `config.xml`, triggering a `customscheme` event on the
+browser. Multiple values are separated by comma's.
+
+In `config.xml`, include the following:
+```xml
+<preference name="AllowedSchemes" value="app" />
+```
+
+```javascript
+function onCustomScheme(e) {
+  if (e.url === 'app://hide') {
+    inAppBrowserRef.hide();
+  }
+}
+inAppBrowserRef = cordova.InAppBrowser.open('https://example.com', '_blank');
+inAppBrowserRef.addEventListener('customscheme', onCustomScheme);
+```
+
+When the opened page navigates to the link `app://hide`, the browser is hidden.
+
+Please note that this feature is only available on Android and iOS (pull requests
+for other platforms are welcome).
 
 ## More Usage Info
 

--- a/src/android/BrowserEventSender.java
+++ b/src/android/BrowserEventSender.java
@@ -17,6 +17,7 @@ public class BrowserEventSender {
     private static final String HIDDEN_EVENT = "hidden";
     private static final String UNHIDDEN_EVENT = "unhidden";
     private static final String BRIDGE_RESPONSE_EVENT = "bridgeresponse";
+    private static final String CUSTOM_SCHEME_EVENT = "customscheme";
 
     private PluginResultSender pluginResultSender;
 
@@ -51,6 +52,16 @@ public class BrowserEventSender {
             pluginResultSender.ok(responseObject);
         } catch (JSONException ex) {
             Log.d(LOG_TAG, "Failed to build poll result response object");
+        }
+    }
+
+    public void customScheme(String url) {
+        try {
+            JSONObject responseObject = CreateResponse(CUSTOM_SCHEME_EVENT);
+            responseObject.put("data", url);
+            pluginResultSender.ok(responseObject);
+        } catch (JSONException ex) {
+            Log.d(LOG_TAG, "Failed to build custom scheme result response object");
         }
     }
 

--- a/src/android/BrowserEventSender.java
+++ b/src/android/BrowserEventSender.java
@@ -58,7 +58,7 @@ public class BrowserEventSender {
     public void customScheme(String url) {
         try {
             JSONObject responseObject = CreateResponse(CUSTOM_SCHEME_EVENT);
-            responseObject.put("data", url);
+            responseObject.put("url", url);
             pluginResultSender.ok(responseObject);
         } catch (JSONException ex) {
             Log.d(LOG_TAG, "Failed to build custom scheme result response object");

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -912,6 +912,7 @@ public class InAppBrowser extends CordovaPlugin {
     public class InAppBrowserClient extends WebViewClient {
         EditText edittext;
         CordovaWebView webView;
+        String[] allowedSchemes;
 
         /**
          * Constructor.
@@ -922,6 +923,22 @@ public class InAppBrowser extends CordovaPlugin {
         public InAppBrowserClient(CordovaWebView webView, EditText mEditText) {
             this.webView = webView;
             this.edittext = mEditText;
+            this.allowedSchemes = preferences.getString("AllowedSchemes", "").split(",");
+        }
+
+        /**
+         * Handles custom url schemes by sending customscheme events the local browser
+         */
+        public boolean handleCustomUrlScheme(String url) {
+            if (allowedSchemes != null && allowedSchemes.length != 0) {
+                for (String scheme : allowedSchemes) {
+                    if (url.startsWith(scheme)) {
+                        browserEventSender.customScheme(url);
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         /**
@@ -945,7 +962,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
             if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
-                return IntentHandler.customScheme(url, browserEventSender);
+                return handleCustomUrlScheme(url);
             }
             return false;
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -945,7 +945,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
             if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
-                return IntentHandler.customScheme(url, BrowserEventSender);
+                return IntentHandler.customScheme(url, browserEventSender);
             }
             return false;
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -945,7 +945,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
             if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
-                return IntentHandler.customScheme(url, cordova.getActivity());
+                return IntentHandler.customScheme(url, BrowserEventSender);
             }
             return false;
         }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -943,6 +943,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (url.startsWith("sms:")) {
                 return IntentHandler.sms(url, cordova.getActivity());
             }
+            // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
+            if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
+                return IntenetHandler.customScheme(url, cordova.getActivity());
+            }
             return false;
         }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -945,7 +945,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             // Test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
             if (!url.startsWith("http:") && !url.startsWith("https:") && url.matches("^[a-z]*://.*?$")) {
-                return IntenetHandler.customScheme(url, cordova.getActivity());
+                return IntentHandler.customScheme(url, cordova.getActivity());
             }
             return false;
         }

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -2,7 +2,6 @@ package org.apache.cordova.inappbrowser;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
@@ -10,7 +9,7 @@ import org.apache.cordova.LOG;
 
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";
-    private IntentHandler (){}
+    private  IntentHandler (){ }
 
     public static Boolean dial(String url, Activity parentActivity){
         try {

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -9,7 +9,12 @@ import org.apache.cordova.LOG;
 
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";
-    private  IntentHandler (){ }
+    private static String[] allowedSchemes;
+
+    private IntentHandler (){
+        String allowed = preferences.getString("AllowedSchemes", "");
+        IntentHandler.allowedSchemes = allowed.split(",");
+    }
 
     public static Boolean dial(String url, Activity parentActivity){
         try {
@@ -67,5 +72,24 @@ public final class IntentHandler {
             LOG.e(LOG_TAG, "Error with " + url + ": " + e.toString());
             return false;
         }
+    }
+
+    public static Boolean customScheme(String url, Activity parentActivity) {
+        if (allowedSchemes != null && allowedSchemes.length != 0) {
+            for (String scheme : allowedSchemes) {
+                if (url.startsWith(scheme)) {
+                    try {
+                        JSONObject obj = new JSONObject();
+                        obj.put("type", "customscheme");
+                        obj.put("url", url);
+                        sendUpdate(obj, true);
+                        return true;
+                    } catch (JSONException ex) {
+                        LOG.e(LOG_TAG, "Custom Scheme URI passed in has caused a JSON error.");
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -10,11 +10,7 @@ import org.apache.cordova.LOG;
 
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";
-    private static String[] allowedSchemes;
-    private IntentHandler (){
-        String allowed = preferences.getString("AllowedSchemes", "");
-        IntentHandler.allowedSchemes = allowed.split(",");
-    }
+    private IntentHandler (){}
 
     public static Boolean dial(String url, Activity parentActivity){
         try {
@@ -72,17 +68,5 @@ public final class IntentHandler {
             LOG.e(LOG_TAG, "Error with " + url + ": " + e.toString());
             return false;
         }
-    }
-
-    public static Boolean customScheme(String url, BrowserEventSender eventSender) {
-        if (allowedSchemes != null && allowedSchemes.length != 0) {
-            for (String scheme : allowedSchemes) {
-                if (url.startsWith(scheme)) {
-                    eventSender.customScheme(url);
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -2,6 +2,7 @@ package org.apache.cordova.inappbrowser;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
@@ -10,7 +11,6 @@ import org.apache.cordova.LOG;
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";
     private static String[] allowedSchemes;
-
     private IntentHandler (){
         String allowed = preferences.getString("AllowedSchemes", "");
         IntentHandler.allowedSchemes = allowed.split(",");

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 import org.apache.cordova.LOG;
+import org.json.JSONObject;
 
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";

--- a/src/android/IntentHandler.java
+++ b/src/android/IntentHandler.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 import org.apache.cordova.LOG;
-import org.json.JSONObject;
 
 public final class IntentHandler {
     private static final String LOG_TAG = "InAppBrowser.IntentHandler";
@@ -75,19 +74,12 @@ public final class IntentHandler {
         }
     }
 
-    public static Boolean customScheme(String url, Activity parentActivity) {
+    public static Boolean customScheme(String url, BrowserEventSender eventSender) {
         if (allowedSchemes != null && allowedSchemes.length != 0) {
             for (String scheme : allowedSchemes) {
                 if (url.startsWith(scheme)) {
-                    try {
-                        JSONObject obj = new JSONObject();
-                        obj.put("type", "customscheme");
-                        obj.put("url", url);
-                        sendUpdate(obj, true);
-                        return true;
-                    } catch (JSONException ex) {
-                        LOG.e(LOG_TAG, "Custom Scheme URI passed in has caused a JSON error.");
-                    }
+                    eventSender.customScheme(url);
+                    return true;
                 }
             }
         }

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -302,8 +302,7 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
 
 }
 
-- (BOOL)isAllowedScheme:(NSString*)scheme
-{
+- (BOOL)isWhitelistedCustomScheme:(NSString*)scheme {
     NSString* allowedSchemesPreference = [self settingForKey:@"AllowedSchemes"];
     if (allowedSchemesPreference == nil || [allowedSchemesPreference isEqualToString:@""]) {
         // Preference missing.
@@ -344,7 +343,7 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
     }
 
     //test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
-    if (![[ url scheme] isEqualToString:@"http"] && ![[ url scheme] isEqualToString:@"https"] && [self isAllowedScheme:[url scheme]]) {
+    if (![[url scheme] isEqualToString:@"http"] && ![[url scheme] isEqualToString:@"https"] && [self isWhitelistedCustomScheme:[url scheme]]) {
         // Send a customscheme event.
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                       messageAsDictionary:@{@"type":@"customscheme", @"url":[url absoluteString]}];

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -94,6 +94,10 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
     _callbackIdPattern = nil;
 }
 
+- (id)settingForKey:(NSString*)key {
+    return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
+}
+
 - (void)onReset {
     [self close:nil];
 }
@@ -298,6 +302,21 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
 
 }
 
+- (BOOL)isAllowedScheme:(NSString*)scheme
+{
+    NSString* allowedSchemesPreference = [self settingForKey:@"AllowedSchemes"];
+    if (allowedSchemesPreference == nil || [allowedSchemesPreference isEqualToString:@""]) {
+        // Preference missing.
+        return NO;
+    }
+    for (NSString* allowedScheme in [allowedSchemesPreference componentsSeparatedByString:@","]) {
+        if ([allowedScheme isEqualToString:scheme]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 /**
  * The iframe bridge provided for the InAppBrowser is capable of executing any oustanding callback belonging
  * to the InAppBrowser plugin. Care has been taken that other callbacks cannot be triggered, and that no
@@ -321,6 +340,16 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
     // and the path, if present, should be a JSON-encoded value to pass to the callback.
     if ([[url scheme] isEqualToString:@"gap-iab"]) {
         [self handleInjectedScriptCallBack: url];
+        return NO;
+    }
+
+    //test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
+    if (![[ url scheme] isEqualToString:@"http"] && ![[ url scheme] isEqualToString:@"https"] && [self isAllowedScheme:[url scheme]]) {
+        // Send a customscheme event.
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                      messageAsDictionary:@{@"type":@"customscheme", @"url":[url absoluteString]}];
+        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
         return NO;
     }
 
@@ -456,14 +485,6 @@ const int INITIAL_STATUS_BAR_STYLE = -1;
                                                       messageAsDictionary:@{@"type":@"loaderror", @"url":url, @"code": [NSNumber numberWithInteger:error.code], @"message": error.localizedDescription}];
         [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
 
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-    }
-    //test for whitelisted custom scheme names like mycoolapp:// or twitteroauthresponse:// (Twitter Oauth Response)
-    else if (![[url scheme] isEqualToString:@"http"] && ![[url scheme] isEqualToString:@"https"] && [self isAllowedScheme:[url scheme]]) {
-        // Send a customscheme event.
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                      messageAsDictionary:@{@"type":@"customscheme", @"url":[url absoluteString]}];
-        [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
     }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -632,4 +632,30 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('Anchor2', function () {
         doOpen(localhtml + '#anchor2', '_blank');
     }, 'openAnchor2');
+
+    // Customscheme
+    createActionButton('customscheme', function () {
+
+        var ref = cordova.InAppBrowser.open('about:blank', '_blank', 'hidden=yes' + 'usewkwebview=no');
+        var openedCustomscheme = false;
+        ref.addEventListener('loadstop', function (e) {
+            // Avoid showing the alert twice on iOS, since loadstop is also being called after the customscheme event.
+            if (!openedCustomscheme) {
+                openedCustomscheme = true;
+                ref.executeScript({ code: 'window.location.replace("custom://test");' });
+            }
+        });
+        ref.addEventListener('customscheme', function (e) {
+            if (e && e.url === 'custom://test') {
+                alert('Results verified'); // eslint-disable-line no-undef
+            } else {
+                alert('Got: ' + e.url); // eslint-disable-line no-undef
+            }
+            ref.close();
+        });
+        ref.addEventListener('loaderror', function (e) {
+            alert('Load error: ' + e.message + '\nYou may need to set the AllowedSchemes preference'); // eslint-disable-line no-undef
+            ref.close();
+        });
+    }, 'openCustomscheme');
 };

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -56,7 +56,8 @@
             'hidden' : channel.create('hidden'),
             'unhidden' : channel.create('unhidden'),
             'bridgeresponse' : channel.create('bridgeresponse'),
-            'exit' : channel.create('exit')
+            'exit' : channel.create('exit'),
+            'customscheme' : channel.create('customscheme')
         };
 
         me.close = function (eventname) {

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -47,7 +47,7 @@
 
         me.isHidden = function(){
             return hidden;
-        }
+        };
 
         me.channels = {
             'loadstart': channel.create('loadstart'),
@@ -57,27 +57,27 @@
             'unhidden' : channel.create('unhidden'),
             'bridgeresponse' : channel.create('bridgeresponse'),
             'exit' : channel.create('exit')
-        }
+        };
 
         me.close = function (eventname) {
             exec(null, null, "InAppBrowser", "close", []);
             hidden = false;
-        }
+        };
 
         me.show = function (eventname) {
             exec(null, null, "InAppBrowser", "show", []);
             hidden = false;
-        }
+        };
 
         me.hide = function (releaseResources, boolGoToBlank, eventname) {
             exec(null,null,"InAppBrowser", "hide", [releaseResources, boolGoToBlank]);
             hidden = true;
-        }
+        };
 
         me.unHide = function (strUrl, eventname) {
             exec(null,null,"InAppBrowser", "unHide", [strUrl]);
             hidden = false;
-        }
+        };
 
         me.update = function (strUrl, show) {
             exec(null,null,"InAppBrowser", "update", [strUrl, show]);
@@ -89,19 +89,19 @@
 
         me.bridge = function (objectName, bridgeFunction) {
             exec(null, null, "InAppBrowser", "bridge", [objectName, bridgeFunction]);
-        }
+        };
 
         me.addEventListener = function (eventname,f) {
             if (eventname in me.channels) {
                 me.channels[eventname].subscribe(f);
             }
-        }
+        };
 
         me.removeEventListener = function (eventname, f) {
             if (eventname in me.channels) {
                 me.channels[eventname].unsubscribe(f);
             }
-        }
+        };
 
         me.executeScript = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -111,7 +111,7 @@
             } else {
                 throw new Error('executeScript requires exactly one of code or file to be specified');
             }
-        }
+        };
 
         me.insertCSS = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -121,7 +121,7 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
-        }
+        };
 
 
        for (var callbackName in callbacks) {

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -47,10 +47,10 @@
 
         me.isHidden = function(){
             return hidden;
-        };
+        }
 
         me.channels = {
-            'loadstart': channel.create('loadstart'),
+            'loadstart' : channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
             'hidden' : channel.create('hidden'),
@@ -58,27 +58,27 @@
             'bridgeresponse' : channel.create('bridgeresponse'),
             'exit' : channel.create('exit'),
             'customscheme' : channel.create('customscheme')
-        };
+        }
 
         me.close = function (eventname) {
             exec(null, null, "InAppBrowser", "close", []);
             hidden = false;
-        };
+        }
 
         me.show = function (eventname) {
             exec(null, null, "InAppBrowser", "show", []);
             hidden = false;
-        };
+        }
 
         me.hide = function (releaseResources, boolGoToBlank, eventname) {
             exec(null,null,"InAppBrowser", "hide", [releaseResources, boolGoToBlank]);
             hidden = true;
-        };
+        }
 
         me.unHide = function (strUrl, eventname) {
             exec(null,null,"InAppBrowser", "unHide", [strUrl]);
             hidden = false;
-        };
+        }
 
         me.update = function (strUrl, show) {
             exec(null,null,"InAppBrowser", "update", [strUrl, show]);
@@ -90,19 +90,19 @@
 
         me.bridge = function (objectName, bridgeFunction) {
             exec(null, null, "InAppBrowser", "bridge", [objectName, bridgeFunction]);
-        };
+        }
 
         me.addEventListener = function (eventname,f) {
             if (eventname in me.channels) {
                 me.channels[eventname].subscribe(f);
             }
-        };
+        }
 
         me.removeEventListener = function (eventname, f) {
             if (eventname in me.channels) {
                 me.channels[eventname].unsubscribe(f);
             }
-        };
+        }
 
         me.executeScript = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -112,7 +112,7 @@
             } else {
                 throw new Error('executeScript requires exactly one of code or file to be specified');
             }
-        };
+        }
 
         me.insertCSS = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -122,7 +122,7 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
-        };
+        }
 
 
        for (var callbackName in callbacks) {

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -33,13 +33,14 @@
 
     function InAppBrowser() {
        this.channels = {
-            'loadstart': channel.create('loadstart'),
+            'loadstart' : channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
             'hidden' : channel.create('hidden'),
             'unhidden' : channel.create('unhidden'),
             'bridgeresponse' : channel.create('bridgeresponse'),
-            'exit' : channel.create('exit')
+            'exit' : channel.create('exit'),
+            'customscheme' : channel.create('customscheme')
        };
     }
 

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -60,9 +60,9 @@
             }
         }
 
-        backChannels.preventexitonhide.subscribe(function(){
+        backChannels['preventexitonhide'].subscribe(function(){
                 var exitHandlersToRestore = {},
-                exitChannel = me.channels.exit,
+                exitChannel = me.channels['exit'],
                 exitRestoreCallBack = function(){
                     // This cleans up the current handler
                     if(exitRestoreCallBack.observer_guid){
@@ -89,7 +89,7 @@
         });
 
         me.channels = {
-            'loadstart': channel.create('loadstart'),
+            'loadstart' : channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
             'hidden' : channel.create('hidden'),
@@ -101,20 +101,20 @@
 
         me.isHidden = function(){
             return hidden;
-        };
+        }
 
         me.close = function(eventname) {
             exec(null, null, "InAppBrowser", "close", []);
             if(hidden){
-                me.channels.exit.fire();
+                me.channels['exit']fire();
             }
             hidden = false;
-        };
+        }
 
         me.show = function(eventname) {
             exec(null, null, "InAppBrowser", "show", []);
             hidden = false;
-        };
+        }
 
         me.hide = function(releaseResources, blankPage){
 
@@ -126,7 +126,7 @@
             // Is fully closed & the JS pretends it isn't
             exec(null,null,"InAppBrowser", "hide", [releaseResources]);
             hidden = true;
-        };
+        }
 
         me.unHide = function(strUrl, eventname){
             if(strUrl){
@@ -135,7 +135,7 @@
 
             exec(eventCallback, eventCallback, "InAppBrowser", "unHide", [lastUrl, lastWindowName, lastWindowFeatures]);
             hidden = false;
-        };
+        }
 
         me.update = function (strUrl, show) {
             if (strUrl) {
@@ -153,13 +153,13 @@
             if (eventname in me.channels) {
                 me.channels[eventname].subscribe(f);
             }
-        };
+        }
 
         me.removeEventListener = function (eventname, f) {
             if (eventname in me.channels) {
                 me.channels[eventname].unsubscribe(f);
             }
-        };
+        }
 
         me.executeScript = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -169,7 +169,7 @@
             } else {
                 throw new Error('executeScript requires exactly one of code or file to be specified');
             }
-        };
+        }
 
         me.insertCSS = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -179,14 +179,14 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
-        };
+        }
 
         for (var callbackName in callbacks) {
             me.addEventListener(callbackName, callbacks[callbackName]);
         }
 
         exec(eventCallback, eventCallback, "InAppBrowser", "open", [lastUrl, lastWindowName, lastWindowFeatures]);
-    };
+    }
 
     module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
         // Don't catch calls that write to existing frames (e.g. named iframes).

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -60,9 +60,9 @@
             }
         }
 
-        backChannels['preventexitonhide'].subscribe(function(){
+        backChannels.preventexitonhide.subscribe(function(){
                 var exitHandlersToRestore = {},
-                exitChannel = me.channels['exit'],
+                exitChannel = me.channels.exit,
                 exitRestoreCallBack = function(){
                     // This cleans up the current handler
                     if(exitRestoreCallBack.observer_guid){
@@ -96,24 +96,24 @@
             'unhidden' : channel.create('unhidden'),
             'bridgeresponse' : channel.create('bridgeresponse'),
             'exit' : channel.create('exit')
-        }
+        };
 
         me.isHidden = function(){
             return hidden;
-        }
+        };
 
         me.close = function(eventname) {
             exec(null, null, "InAppBrowser", "close", []);
             if(hidden){
-                me.channels['exit'].fire();
+                me.channels.exit.fire();
             }
             hidden = false;
-        }
+        };
 
         me.show = function(eventname) {
             exec(null, null, "InAppBrowser", "show", []);
             hidden = false;
-        }
+        };
 
         me.hide = function(releaseResources, blankPage){
 
@@ -125,7 +125,7 @@
             // Is fully closed & the JS pretends it isn't
             exec(null,null,"InAppBrowser", "hide", [releaseResources]);
             hidden = true;
-        }
+        };
 
         me.unHide = function(strUrl, eventname){
             if(strUrl){
@@ -134,7 +134,7 @@
 
             exec(eventCallback, eventCallback, "InAppBrowser", "unHide", [lastUrl, lastWindowName, lastWindowFeatures]);
             hidden = false;
-        }
+        };
 
         me.update = function (strUrl, show) {
             if (strUrl) {
@@ -152,13 +152,13 @@
             if (eventname in me.channels) {
                 me.channels[eventname].subscribe(f);
             }
-        }
+        };
 
         me.removeEventListener = function (eventname, f) {
             if (eventname in me.channels) {
                 me.channels[eventname].unsubscribe(f);
             }
-        }
+        };
 
         me.executeScript = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -168,7 +168,7 @@
             } else {
                 throw new Error('executeScript requires exactly one of code or file to be specified');
             }
-        }
+        };
 
         me.insertCSS = function (injectDetails, cb) {
             if (injectDetails.code) {
@@ -178,14 +178,14 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
-        }
+        };
 
         for (var callbackName in callbacks) {
             me.addEventListener(callbackName, callbacks[callbackName]);
         }
 
         exec(eventCallback, eventCallback, "InAppBrowser", "open", [lastUrl, lastWindowName, lastWindowFeatures]);
-    }
+    };
 
     module.exports = function(strUrl, strWindowName, strWindowFeatures, callbacks) {
         // Don't catch calls that write to existing frames (e.g. named iframes).

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -106,7 +106,7 @@
         me.close = function(eventname) {
             exec(null, null, "InAppBrowser", "close", []);
             if(hidden){
-                me.channels['exit']fire();
+                me.channels['exit'].fire();
             }
             hidden = false;
         }

--- a/www/ios/inappbrowser.js
+++ b/www/ios/inappbrowser.js
@@ -95,7 +95,8 @@
             'hidden' : channel.create('hidden'),
             'unhidden' : channel.create('unhidden'),
             'bridgeresponse' : channel.create('bridgeresponse'),
-            'exit' : channel.create('exit')
+            'exit' : channel.create('exit'),
+            'customscheme' : channel.create('customscheme')
         };
 
         me.isHidden = function(){


### PR DESCRIPTION
This PR adds support for Custom URL Schemes in our inAppBrowser Fork. When the InAppBrowser is directed to a Custom URL Scheme it will send a new event to the Cordova Webview called "customscheme" which will allow for the client to manage what it would like to do with the Custom URL Scheme.

This implementation is ported from the current InAppBrowser repo. 