### PR TITLE
No jira/orientation locking issue

### DIFF
--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -29,6 +29,7 @@
 
 @interface CDVWKInAppBrowser : CDVPlugin {
     UIWindow * tmpWindow;
+    UIWindow * cordovaWindow;
 
     @private
     NSString* _beforeload;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1243,7 +1243,7 @@ BOOL isExiting = FALSE;
         isExiting = TRUE;
         if ([weakSelf respondsToSelector:@selector(presentingViewController)]) {
             [[weakSelf presentingViewController] dismissViewControllerAnimated:YES completion:nil];
-        } else if ([weakSelf parentViewController]) {
+        } else {
             [[weakSelf parentViewController] dismissViewControllerAnimated:YES completion:nil];
         }
     });

--- a/src/ios/WindowState.h
+++ b/src/ios/WindowState.h
@@ -16,4 +16,5 @@
     - (bool)canOpen;
     - (bool)isHidden;
     - (bool)isUnhiding;
+
 @end

--- a/src/ios/WindowState.m
+++ b/src/ios/WindowState.m
@@ -134,7 +134,7 @@ WindowStates currentState;
 
 - (bool)canOpen
 {
-    return currentState == Ready;
+    return currentState == Ready || currentState == Exited;
 }
 
 - (bool)isHidden


### PR DESCRIPTION
This PR has a couple of fixes to bring it back to the original UIWebview implementation and fix a bug that prevented us from locking the orientation of the device

The web view was not being destroyed on hide which in the previous UIWebview version it was. I was going to leave this to keep it consistent with Android but since we are destroying the UIWindow to fix another bug it makes more sense.

This plugin instantiated a new window and root view controller in order to display the IAB Webview on top of the current Cordova Webview. However the base root view controller has defaults for supported orientations. Therefore it will still orientate regardless of the other UIWindows. This wont orientate the Cordova Webview as it is not a child of this window but it will orientate Global objects like the status bar. In our case this created a very odd bug where we locked the Cordova UIWindow from orientating but another UIWindow still forced the status bar to orientate.
