### PR TITLE
Changed how visibility works to prevent pages from bugging and not lo…

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -285,7 +285,7 @@ public class InAppBrowser extends CordovaPlugin {
             return true;
         }
         if (action.equals("show")) {
-            showDialogue();
+            showDialogue(false);
             return true;
         }
         if (action.equals("hide")) {
@@ -480,7 +480,7 @@ public class InAppBrowser extends CordovaPlugin {
     private void unHideDialog(final String url) {
         if (url == null || url.equals("") || url.equals(NULL)) {
             addBridgeInterface();
-            showDialogue();
+            showDialogue(false);
             return;
         }
 
@@ -498,12 +498,11 @@ public class InAppBrowser extends CordovaPlugin {
 
                 if (inAppWebView.getUrl().equals(url)) {
                     //unhidden event & reset of hidden flag done in this method ...
-                    showDialogue();
+                    showDialogue(false);
                 } else {
                     //unhidden event & reset of hidden flag done in onPageFinished which results from this navigate ...
                     WindowState.reopenOnNextPageFinished();
-                    inAppWebView.setVisibility(View.INVISIBLE);
-                    showDialogue();
+                    showDialogue(true);
                     navigate(url);
                 }
             }
@@ -515,7 +514,7 @@ public class InAppBrowser extends CordovaPlugin {
             addBridgeInterface();
 
             if (show) {
-                showDialogue();
+                showDialogue(false);
             }
 
             return;
@@ -530,7 +529,7 @@ public class InAppBrowser extends CordovaPlugin {
 
             if (inAppWebView.getUrl().equals(url)) {
                 if (show) {
-                    showDialogue();
+                    showDialogue(false);
                 } else {
                     browserEventSender.loadStop(url);
                     if(WindowState.isHiding()) {
@@ -542,8 +541,7 @@ public class InAppBrowser extends CordovaPlugin {
             } else {
                 if (show) {
                     WindowState.reopenOnNextPageFinished();
-                    inAppWebView.setVisibility(View.INVISIBLE);
-                    showDialogue();
+                    showDialogue(true);
                 }
 
                 navigate(url);
@@ -554,12 +552,16 @@ public class InAppBrowser extends CordovaPlugin {
     /**
      * Shows the dialog in the standard way
      *
-     * @param
+     * @param invisible
      * @return
      */
-    private void showDialogue() {
+    private void showDialogue(Boolean invisible) {
         this.cordova.getActivity().runOnUiThread(() -> {
             if (dialog != null) {
+                if (invisible) {
+                    inAppWebView.setVisibility(View.INVISIBLE);
+                    dialog.getWindow().setFlags(LayoutParams.FLAG_NOT_TOUCHABLE, LayoutParams.FLAG_NOT_TOUCHABLE);
+                }
                 dialog.show();
             }
             if(WindowState.isHidden() || WindowState.isUnhiding()) {
@@ -568,6 +570,11 @@ public class InAppBrowser extends CordovaPlugin {
             }
         });
         pluginResultSender.ok();
+    }
+
+    private void makeDialogueVisible() {
+        inAppWebView.setVisibility(View.VISIBLE);
+        dialog.getWindow().clearFlags(LayoutParams.FLAG_NOT_TOUCHABLE);
     }
 
     /**
@@ -1425,7 +1432,7 @@ public class InAppBrowser extends CordovaPlugin {
                 // https://stackoverflow.com/questions/10592998/android-webview-not-calling-onpagefinished-when-url-redirects
                 // This is fired on every web Frame load and can fail to be invoked if you have redirections before becoming visible
                 // We have changed the functionality to use .setVisibility instead of .show to fix this
-                inAppWebView.setVisibility(View.VISIBLE);
+                makeDialogueVisible();
             }
 
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -551,6 +551,9 @@ public class InAppBrowser extends CordovaPlugin {
 
     /**
      * Shows the dialog in the standard way
+     * invisible boolean parameter allows
+     * you to set the content of the dialogue invisible
+     * useful to get items out of backgrounded state
      *
      * @param invisible
      * @return
@@ -558,6 +561,8 @@ public class InAppBrowser extends CordovaPlugin {
     private void showDialogue(Boolean invisible) {
         this.cordova.getActivity().runOnUiThread(() -> {
             if (dialog != null) {
+                // This should only be used to bring the Webview out of a backgrounded state
+                // to allow it to load if it has been backgrounded for too long.
                 if (invisible) {
                     inAppWebView.setVisibility(View.INVISIBLE);
                     dialog.getWindow().setFlags(LayoutParams.FLAG_NOT_TOUCHABLE, LayoutParams.FLAG_NOT_TOUCHABLE);
@@ -572,6 +577,9 @@ public class InAppBrowser extends CordovaPlugin {
         pluginResultSender.ok();
     }
 
+    /**
+     * Re-enables interaction and sets webview to visible
+     */
     private void makeDialogueVisible() {
         inAppWebView.setVisibility(View.VISIBLE);
         dialog.getWindow().clearFlags(LayoutParams.FLAG_NOT_TOUCHABLE);
@@ -1431,7 +1439,7 @@ public class InAppBrowser extends CordovaPlugin {
                 // https://stackoverflow.com/a/5172952
                 // https://stackoverflow.com/questions/10592998/android-webview-not-calling-onpagefinished-when-url-redirects
                 // This is fired on every web Frame load and can fail to be invoked if you have redirections before becoming visible
-                // We have changed the functionality to use .setVisibility instead of .show to fix this
+                // We have changed the functionality to use .setVisibility instead of .show to fix both this and the idle background issues
                 makeDialogueVisible();
             }
 

--- a/www/android/inappbrowser.js
+++ b/www/android/inappbrowser.js
@@ -130,7 +130,7 @@
         for (var callbackName in callbacks) {
             me.addEventListener(callbackName, callbacks[callbackName]);
         }
- 
+
         exec(eventHandler, eventHandler, "InAppBrowser", "open", [strUrl, strWindowName, strWindowFeatures]);
 
     }


### PR DESCRIPTION
This makes two changes to fix issues that are caused by running the webview in the background before showing it to the user.

1st issue - The renderer is destroyed unexpectedly if the phone tries to clean up it's memory. This is because when a webview is backgrounded it is puts the `setRendererPriorityPolicy` too `waived`. By default when not backgrounded it's in `important` mode. We can prevent this with: `.setRendererPriorityPolicy(RENDERER_PRIORITY_IMPORTANT, false);` where false prevents it from being put into waived mode upon being backgrounded

2nd issue - Due to how the visibility works on a dialogue the webview was being backgrounded. If you wait long enough(approximately 5 minutes) the webview will fail to load pages creating error's. To prevent this we set the visibility to `.setVisibility(View.INVISIBLE)` before starting to load a page and show the dialogue with a transparent background. This acts as a pre-step preparing the dialog for use by pulling it out of it's backgrounded state. Then once the page has loaded we set visibility to `.setVisibility(View.VISIBLE)`. This allows the webview to run like normal preventing the page from erroring